### PR TITLE
Fix dashboard icon mismatch and disable intro text widget

### DIFF
--- a/src/Domain/Dashboard/DashboardLayout.php
+++ b/src/Domain/Dashboard/DashboardLayout.php
@@ -24,7 +24,7 @@ final readonly class DashboardLayout implements \IteratorAggregate
     {
         return [
             ['widget' => 'mostRecentActivities', 'width' => 66, 'enabled' => true, 'config' => ['numberOfActivitiesToDisplay' => 5]],
-            ['widget' => 'introText', 'width' => 33, 'enabled' => true],
+            ['widget' => 'introText', 'width' => 33, 'enabled' => false],
             ['widget' => 'trainingGoals', 'width' => 33, 'enabled' => false, 'config' => ['goals' => []]],
             ['widget' => 'weeklyStats', 'width' => 100, 'enabled' => true, 'config' => ['metricsDisplayOrder' => ['distance', 'movingTime', 'elevation']]],
             ['widget' => 'activityGrid', 'width' => 100, 'enabled' => true],

--- a/templates/html/navigation/breadcrumbs.html.twig
+++ b/templates/html/navigation/breadcrumbs.html.twig
@@ -3,7 +3,7 @@
     <ol class="inline-flex items-center space-x-1 text-sm font-medium md:space-x-2">
         <li class="inline-flex items-center">
             <a href="{{ relativeUrl('dashboard') }}" data-router-navigate="{{ relativeUrl('dashboard') }}" {{ isSymfonyRouter ? 'data-router-disabled' : '' }} class="inline-flex items-center text-gray-700 hover:text-primary-600 hover:underline">
-                <svg class="w-5 h-5 mr-2.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path></svg>
+                <svg class="w-5 h-5 mr-2.5" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6.025A7.5 7.5 0 1 0 17.975 14H10V6.025Z"/><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 3c-.169 0-.334.014-.5.025V11h7.975c.011-.166.025-.331.025-.5A7.5 7.5 0 0 0 13.5 3Z"/></svg>
                 {{ "Dashboard"|trans }}
             </a>
         </li>


### PR DESCRIPTION
- Replace home icon with chart icon in breadcrumbs to match the sidebar dashboard icon (closes #7)
- Disable introText widget in default dashboard layout (closes #3)

https://claude.ai/code/session_01Cs2GRPu68GNtEjduFnsnYC