### PR TITLE
Fix dashboard icons, remove intro text widget, add strength workout parser

### DIFF
--- a/src/Domain/Activity/Strength/ExerciseName.php
+++ b/src/Domain/Activity/Strength/ExerciseName.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Activity\Strength;
+
+use App\Infrastructure\ValueObject\String\NonEmptyStringLiteral;
+
+final readonly class ExerciseName extends NonEmptyStringLiteral
+{
+}

--- a/src/Domain/Activity/Strength/ExerciseSet.php
+++ b/src/Domain/Activity/Strength/ExerciseSet.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Activity\Strength;
+
+use App\Infrastructure\ValueObject\Measurement\Mass\Kilogram;
+
+final readonly class ExerciseSet implements \JsonSerializable
+{
+    private function __construct(
+        private ExerciseName $exerciseName,
+        private int $numberOfSets,
+        private int $numberOfReps,
+        private ?Kilogram $weightInKg,
+    ) {
+        if ($this->numberOfSets <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('Number of sets must be a positive integer, got: %d', $this->numberOfSets)
+            );
+        }
+        if ($this->numberOfReps <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('Number of reps must be a positive integer, got: %d', $this->numberOfReps)
+            );
+        }
+    }
+
+    public static function create(
+        ExerciseName $exerciseName,
+        int $numberOfSets,
+        int $numberOfReps,
+        ?Kilogram $weightInKg = null,
+    ): self {
+        return new self(
+            exerciseName: $exerciseName,
+            numberOfSets: $numberOfSets,
+            numberOfReps: $numberOfReps,
+            weightInKg: $weightInKg,
+        );
+    }
+
+    public function getExerciseName(): ExerciseName
+    {
+        return $this->exerciseName;
+    }
+
+    public function getNumberOfSets(): int
+    {
+        return $this->numberOfSets;
+    }
+
+    public function getNumberOfReps(): int
+    {
+        return $this->numberOfReps;
+    }
+
+    public function getWeightInKg(): ?Kilogram
+    {
+        return $this->weightInKg;
+    }
+
+    public function isBodyweight(): bool
+    {
+        return null === $this->weightInKg;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'exerciseName' => $this->exerciseName,
+            'numberOfSets' => $this->numberOfSets,
+            'numberOfReps' => $this->numberOfReps,
+            'weightInKg' => $this->weightInKg,
+        ];
+    }
+}

--- a/src/Domain/Activity/Strength/StrengthWorkoutDescriptionParser.php
+++ b/src/Domain/Activity/Strength/StrengthWorkoutDescriptionParser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Activity\Strength;
+
+use App\Infrastructure\ValueObject\Measurement\Mass\Kilogram;
+
+final class StrengthWorkoutDescriptionParser
+{
+    // Format: [lift_name] [sets]x[reps]  or  [lift_name] [sets]x[reps]@[weight]
+    // Name must start with a letter; sets/reps must be positive (no zero, no leading zeros).
+    // The lookahead (?=\d+x\d+) anchors the boundary between name and the numeric token,
+    // allowing multi-word names like "Bench Press" without ambiguity.
+    private const string LINE_PATTERN =
+        '/^(?P<name>[A-Za-z][A-Za-z0-9 ]*?)\s+(?=\d+x\d+)(?P<sets>[1-9]\d*)x(?P<reps>[1-9]\d*)(?:@(?P<weight>[0-9]+(?:\.[0-9]+)?))?$/';
+
+    public function parse(string $description): StrengthWorkoutExercises
+    {
+        $exercises = StrengthWorkoutExercises::empty();
+
+        if ('' === trim($description)) {
+            return $exercises;
+        }
+
+        foreach (preg_split('/\r?\n/', $description) as $line) {
+            $trimmed = trim($line);
+            if ('' === $trimmed || !preg_match(self::LINE_PATTERN, $trimmed, $matches)) {
+                continue;
+            }
+
+            $exercises->add(ExerciseSet::create(
+                exerciseName: ExerciseName::fromString($matches['name']),
+                numberOfSets: (int) $matches['sets'],
+                numberOfReps: (int) $matches['reps'],
+                weightInKg: (isset($matches['weight']) && '' !== $matches['weight'])
+                    ? Kilogram::from((float) $matches['weight'])
+                    : null,
+            ));
+        }
+
+        return $exercises;
+    }
+}

--- a/src/Domain/Activity/Strength/StrengthWorkoutExercises.php
+++ b/src/Domain/Activity/Strength/StrengthWorkoutExercises.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Activity\Strength;
+
+use App\Infrastructure\ValueObject\Collection;
+
+/**
+ * @extends Collection<ExerciseSet>
+ */
+final class StrengthWorkoutExercises extends Collection
+{
+    public function getItemClassName(): string
+    {
+        return ExerciseSet::class;
+    }
+}

--- a/tests/Domain/Activity/Strength/ExerciseSetTest.php
+++ b/tests/Domain/Activity/Strength/ExerciseSetTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Activity\Strength;
+
+use App\Domain\Activity\Strength\ExerciseName;
+use App\Domain\Activity\Strength\ExerciseSet;
+use App\Infrastructure\ValueObject\Measurement\Mass\Kilogram;
+use PHPUnit\Framework\TestCase;
+
+class ExerciseSetTest extends TestCase
+{
+    public function testCreateWithWeight(): void
+    {
+        $set = ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Squat'),
+            numberOfSets: 3,
+            numberOfReps: 5,
+            weightInKg: Kilogram::from(100.0),
+        );
+
+        $this->assertEquals('Squat', (string) $set->getExerciseName());
+        $this->assertEquals(3, $set->getNumberOfSets());
+        $this->assertEquals(5, $set->getNumberOfReps());
+        $this->assertEquals(100.0, $set->getWeightInKg()->toFloat());
+        $this->assertFalse($set->isBodyweight());
+    }
+
+    public function testCreateBodyweightExercise(): void
+    {
+        $set = ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Pull Up'),
+            numberOfSets: 3,
+            numberOfReps: 10,
+        );
+
+        $this->assertNull($set->getWeightInKg());
+        $this->assertTrue($set->isBodyweight());
+    }
+
+    public function testJsonSerializeWithWeight(): void
+    {
+        $set = ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Bench Press'),
+            numberOfSets: 4,
+            numberOfReps: 8,
+            weightInKg: Kilogram::from(80.0),
+        );
+
+        $data = $set->jsonSerialize();
+
+        $this->assertSame('Bench Press', (string) $data['exerciseName']);
+        $this->assertSame(4, $data['numberOfSets']);
+        $this->assertSame(8, $data['numberOfReps']);
+        $this->assertSame(80.0, $data['weightInKg']->toFloat());
+    }
+
+    public function testJsonSerializeBodyweight(): void
+    {
+        $set = ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Pull Up'),
+            numberOfSets: 3,
+            numberOfReps: 10,
+        );
+
+        $data = $set->jsonSerialize();
+
+        $this->assertNull($data['weightInKg']);
+    }
+
+    public function testItShouldThrowOnZeroSets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Squat'),
+            numberOfSets: 0,
+            numberOfReps: 5,
+        );
+    }
+
+    public function testItShouldThrowOnNegativeSets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Squat'),
+            numberOfSets: -1,
+            numberOfReps: 5,
+        );
+    }
+
+    public function testItShouldThrowOnZeroReps(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ExerciseSet::create(
+            exerciseName: ExerciseName::fromString('Squat'),
+            numberOfSets: 3,
+            numberOfReps: 0,
+        );
+    }
+}

--- a/tests/Domain/Activity/Strength/StrengthWorkoutDescriptionParserTest.php
+++ b/tests/Domain/Activity/Strength/StrengthWorkoutDescriptionParserTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Activity\Strength;
+
+use App\Domain\Activity\Strength\StrengthWorkoutDescriptionParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class StrengthWorkoutDescriptionParserTest extends TestCase
+{
+    private StrengthWorkoutDescriptionParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new StrengthWorkoutDescriptionParser();
+    }
+
+    #[DataProvider(methodName: 'provideValidSingleLineDescriptions')]
+    public function testParseSingleLine(
+        string $description,
+        string $expectedName,
+        int $expectedSets,
+        int $expectedReps,
+        ?float $expectedWeightKg,
+    ): void {
+        $exercises = $this->parser->parse($description);
+
+        $this->assertCount(1, $exercises);
+        $first = $exercises->getFirst();
+        $this->assertEquals($expectedName, (string) $first->getExerciseName());
+        $this->assertEquals($expectedSets, $first->getNumberOfSets());
+        $this->assertEquals($expectedReps, $first->getNumberOfReps());
+        if (null === $expectedWeightKg) {
+            $this->assertNull($first->getWeightInKg());
+        } else {
+            $this->assertEquals($expectedWeightKg, $first->getWeightInKg()->toFloat());
+        }
+    }
+
+    public static function provideValidSingleLineDescriptions(): iterable
+    {
+        yield 'simple exercise with integer weight' => ['Squat 3x5@100', 'Squat', 3, 5, 100.0];
+        yield 'multi-word name with weight' => ['Bench Press 4x8@80', 'Bench Press', 4, 8, 80.0];
+        yield 'float weight' => ['Deadlift 1x3@140.5', 'Deadlift', 1, 3, 140.5];
+        yield 'bodyweight exercise (no @weight)' => ['Pull Up 3x10', 'Pull Up', 3, 10, null];
+        yield 'three-word name' => ['Romanian Dead Lift 3x8@60', 'Romanian Dead Lift', 3, 8, 60.0];
+        yield 'leading whitespace trimmed' => ['  Squat 3x5@100', 'Squat', 3, 5, 100.0];
+        yield 'trailing whitespace trimmed' => ['Squat 3x5@100  ', 'Squat', 3, 5, 100.0];
+    }
+
+    #[DataProvider(methodName: 'provideDescriptionsWithNoExercises')]
+    public function testParseReturnsEmptyCollection(string $description): void
+    {
+        $exercises = $this->parser->parse($description);
+
+        $this->assertTrue($exercises->isEmpty());
+    }
+
+    public static function provideDescriptionsWithNoExercises(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'prose only' => ['Rest day, feeling good'];
+        yield 'name starts with digit' => ['3x5@100'];
+        yield 'zero sets rejected by regex' => ['Squat 0x5@100'];
+        yield 'zero reps rejected by regex' => ['Squat 3x0@100'];
+        yield 'trailing @ with no weight' => ['Squat 3x5@'];
+        yield 'missing sets token' => ['Squat x5@100'];
+        yield 'missing reps token' => ['Squat 3x@100'];
+    }
+
+    public function testParseMultiLineCanonicalExample(): void
+    {
+        $description = implode("\n", [
+            'Squat 3x5@100',
+            'Bench Press 4x8@80',
+            'Deadlift 1x3@140',
+            'Pull Up 3x10',
+        ]);
+
+        $exercises = $this->parser->parse($description);
+        $this->assertCount(4, $exercises);
+
+        $items = $exercises->toArray();
+        $this->assertEquals('Squat', (string) $items[0]->getExerciseName());
+        $this->assertEquals(3, $items[0]->getNumberOfSets());
+        $this->assertEquals(5, $items[0]->getNumberOfReps());
+        $this->assertEquals(100.0, $items[0]->getWeightInKg()->toFloat());
+
+        $this->assertEquals('Bench Press', (string) $items[1]->getExerciseName());
+        $this->assertEquals(4, $items[1]->getNumberOfSets());
+        $this->assertEquals(8, $items[1]->getNumberOfReps());
+        $this->assertEquals(80.0, $items[1]->getWeightInKg()->toFloat());
+
+        $this->assertEquals('Deadlift', (string) $items[2]->getExerciseName());
+        $this->assertEquals(1, $items[2]->getNumberOfSets());
+        $this->assertEquals(3, $items[2]->getNumberOfReps());
+        $this->assertEquals(140.0, $items[2]->getWeightInKg()->toFloat());
+
+        $this->assertEquals('Pull Up', (string) $items[3]->getExerciseName());
+        $this->assertTrue($items[3]->isBodyweight());
+    }
+
+    public function testParseMultiLineWithMixedContent(): void
+    {
+        $description = implode("\n", [
+            'Good session today!',
+            'Squat 3x5@100',
+            'Felt strong.',
+            'Bench Press 4x8@80',
+            'Pull Up 3x10',
+            'Cool down stretches done.',
+        ]);
+
+        $exercises = $this->parser->parse($description);
+        $this->assertCount(3, $exercises);
+
+        $items = $exercises->toArray();
+        $this->assertEquals('Squat', (string) $items[0]->getExerciseName());
+        $this->assertEquals('Bench Press', (string) $items[1]->getExerciseName());
+        $this->assertEquals('Pull Up', (string) $items[2]->getExerciseName());
+    }
+
+    public function testParseCrlfLineEndings(): void
+    {
+        $description = "Squat 3x5@100\r\nBench Press 4x8@80\r\nPull Up 3x10";
+
+        $exercises = $this->parser->parse($description);
+        $this->assertCount(3, $exercises);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix #7** — Replace mismatched home icon with chart icon in breadcrumbs navigation, matching the sidebar dashboard icon
- **Fix #3** — Disable the "Since I began using Strava..." intro text widget in the default dashboard layout
- **Fix #1 (phase 1)** — Add a pure-domain parser for structured strength workout descriptions in the format `[lift_name] [sets]x[reps]@[weight]`

## Strength Workout Parser Details

New classes under `src/Domain/Activity/Strength/`:

| Class | Purpose |
|---|---|
| `ExerciseName` | String value object for the lift name |
| `ExerciseSet` | Immutable value object: name + sets + reps + optional weight (kg) |
| `StrengthWorkoutExercises` | Typed collection of `ExerciseSet` |
| `StrengthWorkoutDescriptionParser` | Stateless parser — splits description by line, matches `[lift_name] [sets]x[reps]@[weight]`, silently skips non-matching lines (prose/notes) |

**Format examples parsed:**
```
Squat 3x5@100
Bench Press 4x8@80
Deadlift 1x3@140.5
Pull Up 3x10          ← bodyweight, no @weight needed
Good session today!   ← prose lines silently skipped
```

This is phase 1 only — no DB persistence, no UI, no pipeline integration yet.

## Test Plan

- [ ] Run `make phpunit` — new `ExerciseSetTest` and `StrengthWorkoutDescriptionParserTest` should pass
- [ ] Run `make phpstan` — no type errors
- [ ] Run `make csfix` — code style clean
- [ ] Verify dashboard breadcrumb icon now shows chart (not house) on any page with breadcrumbs
- [ ] Verify intro text widget no longer appears on a fresh dashboard layout

https://claude.ai/code/session_01Cs2GRPu68GNtEjduFnsnYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs2GRPu68GNtEjduFnsnYC)_