### PR TITLE
strength parser uses comma separated values

### DIFF
--- a/src/Domain/Activity/Strength/StrengthWorkoutDescriptionParser.php
+++ b/src/Domain/Activity/Strength/StrengthWorkoutDescriptionParser.php
@@ -8,12 +8,16 @@ use App\Infrastructure\ValueObject\Measurement\Mass\Pound;
 
 final class StrengthWorkoutDescriptionParser
 {
-    // Format: [lift_name] [sets]x[reps]  or  [lift_name] [sets]x[reps]@[weight]
-    // Name must start with a letter; sets/reps must be positive (no zero, no leading zeros).
-    // The lookahead (?=\d+x\d+) anchors the boundary between name and the numeric token,
+    // Extracts the exercise name and the raw tokens string from a line.
+    // The lookahead (?=\d+x\d+) anchors the boundary between name and the first set token,
     // allowing multi-word names like "Bench Press" without ambiguity.
     private const string LINE_PATTERN =
-        '/^(?P<name>[A-Za-z][A-Za-z0-9 ]*?)\s+(?=\d+x\d+)(?P<sets>[1-9]\d*)x(?P<reps>[1-9]\d*)(?:@(?P<weight>\d+(?:\.\d+)?))?$/';
+        '/^(?P<name>[A-Za-z][A-Za-z0-9 ]*?)\s+(?=\d+x\d+)(?P<tokens>.+)$/';
+
+    // Matches a single set token: [sets]x[reps] or [sets]x[reps]@[weight]
+    // Sets/reps must be positive (no zero, no leading zeros).
+    private const string SET_TOKEN_PATTERN =
+        '/^(?P<sets>[1-9]\d*)x(?P<reps>[1-9]\d*)(?:@(?P<weight>\d+(?:\.\d+)?))?$/';
 
     public function parse(string $description): StrengthWorkoutExercises
     {
@@ -32,14 +36,21 @@ final class StrengthWorkoutDescriptionParser
                 continue;
             }
 
-            $exercises->add(ExerciseSet::create(
-                exerciseName: ExerciseName::fromString($matches['name']),
-                numberOfSets: (int) $matches['sets'],
-                numberOfReps: (int) $matches['reps'],
-                weightLbs: isset($matches['weight'])
-                    ? Pound::from((float) $matches['weight'])
-                    : null,
-            ));
+            $exerciseName = ExerciseName::fromString($matches['name']);
+            foreach (preg_split('/\s*,\s*/', $matches['tokens']) ?: [] as $token) {
+                if (!preg_match(self::SET_TOKEN_PATTERN, $token, $t)) {
+                    continue;
+                }
+
+                $exercises->add(ExerciseSet::create(
+                    exerciseName: $exerciseName,
+                    numberOfSets: (int) $t['sets'],
+                    numberOfReps: (int) $t['reps'],
+                    weightLbs: '' !== ($t['weight'] ?? '')
+                        ? Pound::from((float) $t['weight'])
+                        : null,
+                ));
+            }
         }
 
         return $exercises;

--- a/tests/Domain/Activity/Strength/StrengthWorkoutDescriptionParserTest.php
+++ b/tests/Domain/Activity/Strength/StrengthWorkoutDescriptionParserTest.php
@@ -130,4 +130,62 @@ class StrengthWorkoutDescriptionParserTest extends TestCase
         $exercises = $this->parser->parse($description);
         $this->assertCount(3, $exercises);
     }
+
+    public function testParseCommaSeperatedSetsOnOneLine(): void
+    {
+        $exercises = $this->parser->parse('Squat 1x1@350, 2x3@295');
+
+        $this->assertCount(2, $exercises);
+        $items = $exercises->toArray();
+
+        $this->assertEquals('Squat', (string) $items[0]->getExerciseName());
+        $this->assertEquals(1, $items[0]->getNumberOfSets());
+        $this->assertEquals(1, $items[0]->getNumberOfReps());
+        $this->assertEquals(350.0, $items[0]->getWeightLbs()->toFloat());
+
+        $this->assertEquals('Squat', (string) $items[1]->getExerciseName());
+        $this->assertEquals(2, $items[1]->getNumberOfSets());
+        $this->assertEquals(3, $items[1]->getNumberOfReps());
+        $this->assertEquals(295.0, $items[1]->getWeightLbs()->toFloat());
+    }
+
+    public function testParseCommaSeperatedSetsWithBodyweight(): void
+    {
+        $exercises = $this->parser->parse('Pull Up 3x5, 2x8');
+
+        $this->assertCount(2, $exercises);
+        $items = $exercises->toArray();
+
+        $this->assertEquals('Pull Up', (string) $items[0]->getExerciseName());
+        $this->assertEquals(3, $items[0]->getNumberOfSets());
+        $this->assertTrue($items[0]->isBodyweight());
+
+        $this->assertEquals('Pull Up', (string) $items[1]->getExerciseName());
+        $this->assertEquals(2, $items[1]->getNumberOfSets());
+        $this->assertTrue($items[1]->isBodyweight());
+    }
+
+    public function testParseCommaSeperatedSetsMultipleExercises(): void
+    {
+        $description = implode("\n", [
+            'Squat 1x1@350, 2x3@295',
+            'Bench Press 4x8@185',
+            'Pull Up 3x5, 2x8',
+        ]);
+
+        $exercises = $this->parser->parse($description);
+        $this->assertCount(5, $exercises);
+
+        $items = $exercises->toArray();
+        $this->assertEquals('Squat', (string) $items[0]->getExerciseName());
+        $this->assertEquals(350.0, $items[0]->getWeightLbs()->toFloat());
+        $this->assertEquals('Squat', (string) $items[1]->getExerciseName());
+        $this->assertEquals(295.0, $items[1]->getWeightLbs()->toFloat());
+        $this->assertEquals('Bench Press', (string) $items[2]->getExerciseName());
+        $this->assertEquals(185.0, $items[2]->getWeightLbs()->toFloat());
+        $this->assertEquals('Pull Up', (string) $items[3]->getExerciseName());
+        $this->assertTrue($items[3]->isBodyweight());
+        $this->assertEquals('Pull Up', (string) $items[4]->getExerciseName());
+        $this->assertTrue($items[4]->isBodyweight());
+    }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description
LINE_PATTERN now captures name + tokens (everything after the name) rather than a single set
SET_TOKEN_PATTERN (new) matches one SxR@W token
The inner loop splits tokens on commas and parses each token — single-set lines just produce one token, so all existing behavior is preserved
'' !== ($t['weight'] ?? '') replaces the ambiguous isset() check for the optional weight group

Fixes ISSUE_NUMBER
